### PR TITLE
Fix max-scenarios-per-file rule

### DIFF
--- a/src/rules/max-scenarios-per-file.ts
+++ b/src/rules/max-scenarios-per-file.ts
@@ -3,10 +3,13 @@ import { Feature, ResultError } from "../types";
 const _ = require("lodash");
 
 export const name = "max-scenarios-per-file";
+type AvailableConfigs = { "maxScenarios": number; "countOutlineExamples": boolean; };
 const defaultConfig = {
     "maxScenarios": 10,
     "countOutlineExamples": true,
 };
+
+export const availableConfigs: AvailableConfigs = defaultConfig;
 
 export function run(feature: Feature, unused, config): ResultError[] {
     if (!feature) {


### PR DESCRIPTION
Add the `availableConfigs` export to the file, because it was failing when being used.