### PR TITLE
Fix bug that prevents .gherkin-lintignore to be considered

### DIFF
--- a/src/utils/feature-finder.ts
+++ b/src/utils/feature-finder.ts
@@ -45,7 +45,7 @@ export function getFeatureFiles(args: string[], ignoreArg?: any): any[] {
 }
 
 function getIgnorePatterns(ignoreArg) {
-    if (ignoreArg) {
+    if (ignoreArg.length > 0) {
         return ignoreArg;
     } else if (fs.existsSync(defaultIgnoreFileName)) {
     // return an array where each element of the array is a line of the ignore file


### PR DESCRIPTION
Whenever you don't pass in any `-i` argument, the tool checks the ignore patterns as `if(ignoreArg)`, since this is an empty array because of `yargs` default value for the cli argument, it prevents to use the .gherkin-lintignore in every case.

We are fixing the bug by checking the array length instead of the truthiness of the array (which is always true).