### PR TITLE
Fix run error in linux env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import * as logger from "./utils/logger";
 import { getArgumentsParsed } from "./utils/argsParser";
 import { getFeatureFiles } from "./utils/feature-finder";


### PR DESCRIPTION
On linux, when I run `npx gherkin-lint-ts` , I have this error
```
/builds/insight/quality/end-to-end-tests-wdio/node_modules/.bin/gherkin-lint-ts: 1: use strict: not found
/builds/insight/quality/end-to-end-tests-wdio/node_modules/.bin/gherkin-lint-ts: 2: Syntax error: "(" unexpected
```